### PR TITLE
Update react DND hack to use new ref structure

### DIFF
--- a/src/object-table.jsx
+++ b/src/object-table.jsx
@@ -244,21 +244,21 @@ class ObjectTable extends React.PureComponent {
   }
 
   getRowFromRefs(rowId) {
-    // Dumb hack to clean up existing hack.
+    // Dumb hack to clean up existing hack. Accesses underlying elements wrapped in React DnD v8 HOCs.
     let row = this.refs[`object-${rowId}`]
     // Unwrap
-    while (row.decoratedComponentInstance) {
-      row = row.decoratedComponentInstance
+    while (row.decoratedRef) {
+      row = row.decoratedRef.current
     }
     return row
   }
 
   getCellFromRefs(rowId, columnKey) {
-    // Dumb hack to clean up existing hack.
+    // Dumb hack to clean up existing hack. Accesses underlying elements wrapped in React DnD v8 HOCs.
     let cell = this.getRowFromRefs(rowId).refs[`column-${columnKey}`]
     // Unwrap
-    while (cell.decoratedComponentInstance) {
-      cell = cell.decoratedComponentInstance
+    while (cell.decoratedRef) {
+      cell = cell.decoratedRef.current
     }
     return cell
   }


### PR DESCRIPTION
Ugly hack got a little uglier - changes in react dnd versions have changed the ref structure used to access the underlying components.

- [x] Updated react DND hack to use the ref structure found in v8 React DnD